### PR TITLE
Update cpython dependency

### DIFF
--- a/python/snips_nlu_utils_py/Cargo.toml
+++ b/python/snips_nlu_utils_py/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 snips-nlu-utils = { path = "../.." }
-cpython = { version="0.1", default-features=false }
+cpython = { version="0.2.1", default-features=false }


### PR DESCRIPTION
This fixes an issue when trying to build wheels for python3.7.