### PR TITLE
Fixed Config. Toml Parse Error

### DIFF
--- a/python/snips_nlu_utils_py/Cargo.toml
+++ b/python/snips_nlu_utils_py/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 snips-nlu-utils = { path = "../.." }
-cpython = { version="0.2.1", default-features=false }
+cpython = { version="0.2.1", default-features = false }


### PR DESCRIPTION
The python toml package can't parse this line.

##
import toml
 toml.loads('cpython = { version="0.2.1", default-features=false }')
##

generates
toml.decoder.TomlDecodeError: Invalid date or number (line 1 column 1 char 0)

Putting spaces between the fixes this.

SystemInformation:
tom version: 0.10.0
Python 3.6.3
win 10 64-bit